### PR TITLE
Bug: Redirect happens even when fetch fails in paymentSummary.js

### DIFF
--- a/2-copy-of-code/lesson-18/scripts/checkout/paymentSummary.js
+++ b/2-copy-of-code/lesson-18/scripts/checkout/paymentSummary.js
@@ -85,10 +85,11 @@ export function renderPaymentSummary() {
         const order = await response.json();
         addOrder(order);
 
+        window.location.href = 'orders.html';
+
       } catch (error) {
         console.log('Unexpected error. Try again later.');
       }
 
-      window.location.href = 'orders.html';
     });
 }


### PR DESCRIPTION
Hey! @SuperSimpleDev 

I noticed that the app redirects to orders.html even if the fetch request fails.

This happens because window.location.href = 'orders.html'; is outside the try...catch, so it runs no matter what.

Maybe you could move the redirect inside the try block, so it only happens if the fetch is successful?

Example:

try {
  const response = await fetch(...);
  const order = await response.json();
  addOrder(order);

  window.location.href = 'orders.html'; // redirect after success
} catch (error) {
  console.log('Unexpected error. Try again later.');
}

Just a small thing I noticed. Thanks for the cool project! @SuperSimpleDev 